### PR TITLE
README: Bump version nr. in the Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add this to the `Cargo.toml` file of your project:
 
 ```toml
 [dependencies]
-tiny_http = "0.5"
+tiny_http = "0.6"
 ```
 
 Don't forget to add the external crate:


### PR DESCRIPTION
Update the README.md Installation instructions to reflect the fact that version 0.6.0 is out.