### PR TITLE
Fix HTTPS request deadlock

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -83,6 +83,11 @@ impl ClientConnection {
         }
     }
 
+    /// true if the connection is HTTPS
+    pub fn secure(&self) -> bool {
+        self.secure
+    }
+
     /// Reads the next line from self.next_header_source.
     ///
     /// Reads until `CRLF` is reached. The next read will start


### PR DESCRIPTION
Fixes #144.

HTTPS requests were previously running into a deadlock when trying to respond to requests in cases:

- To respond to the request, a lock needs to be obtained for the openssl TLS socket.
- However, meanwhile, [this code](https://github.com/tiny-http/tiny-http/blob/master/src/lib.rs#L333-L335) is using that lock to try to read any subsequent requests.
- But no more requests are going to be sent by the browser until it gets a response to the first one!

This modifies it to wait for each request to finish responding until it goes on to reading the next request.  It works, but it's not perfect; here are some things it doesn't do:
- It's potentially less parallelized with HTTPS than HTTP (but I'm not sure it's possible to do any better)
- Responding to requests out of order with HTTPS won't work (this could conceivably be fixed with some check-is-ready-to-read to supply more requests if they're available)
