### PR TITLE
Add rustls implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ repository = "https://github.com/tiny-http/tiny-http"
 
 [features]
 default = []
-ssl = ["openssl"]
+ssl = ["ssl-openssl"]
+ssl-openssl = ["openssl"]
+ssl-rustls = ["rustls"]
 
 [dependencies]
 ascii = "0.8"
@@ -20,6 +22,7 @@ openssl = { version = "0.10", optional = true }
 url = "1.7"
 chrono = "0.4"
 log = "0.4"
+rustls = { version = "0.14", optional = true }
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/src/util/refined_tcp_stream.rs
+++ b/src/util/refined_tcp_stream.rs
@@ -16,9 +16,9 @@ use std::io::{Read, Write};
 use std::io::Result as IoResult;
 use std::net::{SocketAddr, TcpStream, Shutdown};
 
-#[cfg(feature = "ssl")]
+#[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
 use std::sync::{Arc, Mutex};
-#[cfg(feature = "ssl")]
+#[cfg(feature = "ssl-openssl")]
 use openssl::ssl::SslStream;
 
 pub struct RefinedTcpStream {
@@ -29,8 +29,10 @@ pub struct RefinedTcpStream {
 
 pub enum Stream {
     Http(TcpStream),
-    #[cfg(feature = "ssl")]
+    #[cfg(feature = "ssl-openssl")]
     Https(Arc<Mutex<SslStream<TcpStream>>>),
+    #[cfg(feature = "ssl-rustls")]
+    Https(Arc<Mutex<rustls::StreamOwned<rustls::ServerSession, TcpStream>>>),
 }
 
 impl From<TcpStream> for Stream {
@@ -40,10 +42,18 @@ impl From<TcpStream> for Stream {
     }
 }
 
-#[cfg(feature = "ssl")]
+#[cfg(feature = "ssl-openssl")]
 impl From<SslStream<TcpStream>> for Stream {
     #[inline]
     fn from(stream: SslStream<TcpStream>) -> Stream {
+        Stream::Https(Arc::new(Mutex::new(stream)))
+    }
+}
+
+#[cfg(feature = "ssl-rustls")]
+impl From<rustls::StreamOwned<rustls::ServerSession, TcpStream>> for Stream {
+    #[inline]
+    fn from(stream: rustls::StreamOwned<rustls::ServerSession, TcpStream>) -> Stream {
         Stream::Https(Arc::new(Mutex::new(stream)))
     }
 }
@@ -56,8 +66,10 @@ impl RefinedTcpStream {
 
         let read = match stream {
             Stream::Http(ref stream) => Stream::Http(stream.try_clone().unwrap()),
-            #[cfg(feature = "ssl")]
-            Stream::Https(ref stream) => Stream::Https(stream.clone()),
+            #[cfg(feature = "ssl-openssl")]
+            Stream::Https(ref stream) => Stream::Https(Arc::clone(stream)),
+            #[cfg(feature = "ssl-rustls")]
+            Stream::Https(ref stream) => Stream::Https(Arc::clone(stream)),
         };
 
         let read = RefinedTcpStream {
@@ -75,12 +87,12 @@ impl RefinedTcpStream {
         (read, write)
     }
 
-    /// Returns true if this struct wraps arounds a secure connection.
+    /// Returns true if this struct wraps around a secure connection.
     #[inline]
     pub fn secure(&self) -> bool {
         match self.stream {
             Stream::Http(_) => false,
-            #[cfg(feature = "ssl")]
+            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
             Stream::Https(_) => true,
         }
     }
@@ -88,8 +100,10 @@ impl RefinedTcpStream {
     pub fn peer_addr(&mut self) -> IoResult<SocketAddr> {
         match self.stream {
             Stream::Http(ref mut stream) => stream.peer_addr(),
-            #[cfg(feature = "ssl")]
+            #[cfg(feature = "ssl-openssl")]
             Stream::Https(ref mut stream) => stream.lock().unwrap().get_ref().peer_addr(),
+            #[cfg(feature = "ssl-rustls")]
+            Stream::Https(ref mut stream) => stream.lock().unwrap().sock.peer_addr(),
         }
     }
 }
@@ -100,8 +114,10 @@ impl Drop for RefinedTcpStream {
             match self.stream {
                 // ignoring outcome
                 Stream::Http(ref mut stream) => stream.shutdown(Shutdown::Read).ok(),
-                #[cfg(feature = "ssl")]
+                #[cfg(feature = "ssl-openssl")]
                 Stream::Https(ref mut stream) => stream.lock().unwrap().get_mut().shutdown(Shutdown::Read).ok(),
+                #[cfg(feature = "ssl-rustls")]
+                Stream::Https(ref mut stream) => stream.lock().unwrap().sock.shutdown(Shutdown::Read).ok(),
             };
         }
 
@@ -109,8 +125,10 @@ impl Drop for RefinedTcpStream {
             match self.stream {
                 // ignoring outcome
                 Stream::Http(ref mut stream) => stream.shutdown(Shutdown::Write).ok(),
-                #[cfg(feature = "ssl")]
+                #[cfg(feature = "ssl-openssl")]
                 Stream::Https(ref mut stream) => stream.lock().unwrap().get_mut().shutdown(Shutdown::Write).ok(),
+                #[cfg(feature = "ssl-rustls")]
+                Stream::Https(ref mut stream) => stream.lock().unwrap().sock.shutdown(Shutdown::Write).ok(),
             };
         }
     }
@@ -120,7 +138,9 @@ impl Read for RefinedTcpStream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         match self.stream {
             Stream::Http(ref mut stream) => stream.read(buf),
-            #[cfg(feature = "ssl")]
+            #[cfg(feature = "ssl-openssl")]
+            Stream::Https(ref mut stream) => stream.lock().unwrap().read(buf),
+            #[cfg(feature = "ssl-rustls")]
             Stream::Https(ref mut stream) => stream.lock().unwrap().read(buf),
         }
     }
@@ -130,7 +150,9 @@ impl Write for RefinedTcpStream {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         match self.stream {
             Stream::Http(ref mut stream) => stream.write(buf),
-            #[cfg(feature = "ssl")]
+            #[cfg(feature = "ssl-openssl")]
+            Stream::Https(ref mut stream) => stream.lock().unwrap().write(buf),
+            #[cfg(feature = "ssl-rustls")]
             Stream::Https(ref mut stream) => stream.lock().unwrap().write(buf),
         }
     }
@@ -138,7 +160,9 @@ impl Write for RefinedTcpStream {
     fn flush(&mut self) -> IoResult<()> {
         match self.stream {
             Stream::Http(ref mut stream) => stream.flush(),
-            #[cfg(feature = "ssl")]
+            #[cfg(feature = "ssl-openssl")]
+            Stream::Https(ref mut stream) => stream.lock().unwrap().flush(),
+            #[cfg(feature = "ssl-rustls")]
             Stream::Https(ref mut stream) => stream.lock().unwrap().flush(),
         }
     }


### PR DESCRIPTION
This add the possibility to use `rustls` instead of `openssl`.

Note that the certificate/key in the `examples/` directory doesn't work with the `rustls` implementation because the certificate was generated with a key length of 1024-bit. `rustls` doesn't accept such keys because it's considered poorly secured as of today.