### PR TITLE
Fix critical typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Tiny-http was designed with speed in mind:
  will wait for it to be read before processing the next request. Tiny-http will never wait for
  a request to be answered to read the next one.
  - When a client connection has sent its last request (by sending `Connection: close` header),
- the thread will immediatly stop reading from this client and can be reclaimed, even when the
- request has not yet been answered. The reading part of the socket will also be immediatly closed.
+ the thread will immediately stop reading from this client and can be reclaimed, even when the
+ request has not yet been answered. The reading part of the socket will also be immediately closed.
  - Decoding the client's request is done lazily. If you don't read the request's body, it will not
  be decoded.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ occupied).
 let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
 ```
 
-A newly-created `Server` will immediatly start listening for incoming connections and HTTP
+A newly-created `Server` will immediately start listening for incoming connections and HTTP
 requests.
 
 ## Receiving requests
@@ -131,7 +131,7 @@ mod util;
 
 /// The main class of this library.
 ///
-/// Destroying this object will immediatly close the listening socket and the reading
+/// Destroying this object will immediately close the listening socket and the reading
 ///  part of all the client's connections. Requests that have already been returned by
 ///  the `recv()` function will not close and the responses will be transferred to the client.
 pub struct Server {


### PR DESCRIPTION
This typo actually caused the library to become sentient and eat my computer, so, it's very important.