### PR TITLE
Response: Allow manual handling of Range requests

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -15,9 +15,7 @@ use std::str::FromStr;
 /// Some headers cannot be changed. Trying to define the value
 /// of one of these will have no effect:
 ///
-///  - `Accept-Ranges`
 ///  - `Connection`
-///  - `Content-Range`
 ///  - `Trailer`
 ///  - `Transfer-Encoding`
 ///  - `Upgrade`
@@ -240,9 +238,7 @@ where
         let header = header.into();
 
         // ignoring forbidden headers
-        if header.field.equiv(&"Accept-Ranges")
-            || header.field.equiv(&"Connection")
-            || header.field.equiv(&"Content-Range")
+        if header.field.equiv(&"Connection")
             || header.field.equiv(&"Trailer")
             || header.field.equiv(&"Transfer-Encoding")
             || header.field.equiv(&"Upgrade")


### PR DESCRIPTION
This is a proposal in PR-form. Range support (#12) has been dormant for a long time, and the rejection of the headers currently prevent manual handling of Ranges.

This PR would open up for such manual handling, at least until such time that built-in range handling can be supported.