### PR TITLE
Response: Don't forget `chunked_threshold`

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -295,7 +295,7 @@ where
             headers: self.headers,
             status_code: self.status_code,
             data_length,
-            chunked_threshold: None,
+            chunked_threshold: self.chunked_threshold,
         }
     }
 
@@ -453,7 +453,7 @@ where
             status_code: self.status_code,
             headers: self.headers,
             data_length: self.data_length,
-            chunked_threshold: None,
+            chunked_threshold: self.chunked_threshold,
         }
     }
 }


### PR DESCRIPTION
Make sure any set `chunked_threshold` carries over when boxing or replacing
data.