### PR TITLE
Feature | Getters for Response Status Code & Data Length Properties

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -436,6 +436,16 @@ where
 
         Ok(())
     }
+
+    /// Retrieves the current value of the `Response` status code
+    pub fn status_code(&self) -> StatusCode {
+        self.status_code.clone()
+    }
+
+    /// Retrieves the current value of the `Response` data length
+    pub fn data_length(&self) -> Option<usize> {
+        self.data_length
+    }
 }
 
 impl<R> Response<R>


### PR DESCRIPTION
Implements two methods on `Response` `struct`.

1. `status_code`
2. `data_length`

To act as "Getters" for these private properties in case they are needed by the client.

Im using these methods in an HTTP Server I'm writing, these could help me get both values for logging purposes.