### PR TITLE
Add support for Unix Sockets and allow users to create ClientConnections

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4,11 +4,10 @@ use std::io::Error as IoError;
 use std::io::Result as IoResult;
 use std::io::{BufReader, BufWriter, ErrorKind, Read};
 
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use common::{HTTPVersion, Method};
-use util::RefinedTcpStream;
+use util::{PeerAddr, RefinedTcpStream, Stream};
 use util::{SequentialReader, SequentialReaderBuilder, SequentialWriterBuilder};
 
 use Request;
@@ -17,7 +16,7 @@ use Request;
 /// and return Request objects.
 pub struct ClientConnection {
     // address of the client
-    remote_addr: IoResult<SocketAddr>,
+    remote_addr: PeerAddr,
 
     // sequence of Readers to the stream, so that the data is not read in
     //  the wrong order
@@ -50,11 +49,12 @@ enum ReadError {
 
 impl ClientConnection {
     /// Creates a new ClientConnection that takes ownership of the TcpStream.
-    pub fn new(
-        write_socket: RefinedTcpStream,
-        mut read_socket: RefinedTcpStream,
-    ) -> ClientConnection {
-        let remote_addr = read_socket.peer_addr();
+    pub fn new<S>(stream: S) -> ClientConnection
+    where
+        S: Into<Stream>,
+    {
+        let (mut read_socket, write_socket) = RefinedTcpStream::new(stream);
+        let remote_addr = read_socket.peer_addr().unwrap();
         let secure = read_socket.secure();
 
         let mut source = SequentialReaderBuilder::new(BufReader::with_capacity(1024, read_socket));
@@ -152,7 +152,7 @@ impl ClientConnection {
             path,
             version.clone(),
             headers,
-            *self.remote_addr.as_ref().unwrap(),
+            self.remote_addr.clone(),
             data_source,
             writer,
         )

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,13 +2,13 @@ use std::io::Error as IoError;
 use std::io::{self, Cursor, ErrorKind, Read, Write};
 
 use std::fmt;
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use std::sync::mpsc::Sender;
 
 use chunked_transfer::Decoder;
 use util::EqualReader;
+use util::PeerAddr;
 use {HTTPVersion, Header, Method, Response, StatusCode};
 
 /// Represents an HTTP request made by a client.
@@ -50,7 +50,7 @@ pub struct Request {
     // if this writer is empty, then the request has been answered
     response_writer: Option<Box<dyn Write + Send + 'static>>,
 
-    remote_addr: SocketAddr,
+    remote_addr: PeerAddr,
 
     // true if HTTPS, false if HTTP
     secure: bool,
@@ -126,7 +126,7 @@ pub fn new_request<R, W>(
     path: String,
     version: HTTPVersion,
     headers: Vec<Header>,
-    remote_addr: SocketAddr,
+    remote_addr: PeerAddr,
     mut source_data: R,
     writer: W,
 ) -> Result<Request, RequestCreationError>
@@ -280,7 +280,7 @@ impl Request {
     /// this function will return the address of the proxy and not the address of the actual
     /// user.
     #[inline]
-    pub fn remote_addr(&self) -> &SocketAddr {
+    pub fn remote_addr(&self) -> &PeerAddr {
         &self.remote_addr
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,7 @@
 pub use self::custom_stream::CustomStream;
 pub use self::equal_reader::EqualReader;
 pub use self::messages_queue::MessagesQueue;
-pub use self::refined_tcp_stream::RefinedTcpStream;
+pub use self::refined_tcp_stream::{PeerAddr, RefinedTcpStream, Stream};
 pub use self::sequential::{SequentialReader, SequentialReaderBuilder};
 pub use self::sequential::{SequentialWriter, SequentialWriterBuilder};
 pub use self::task_pool::TaskPool;


### PR DESCRIPTION
This is a WIP patch, I'm looking for feedback to see if it's mergeable in some form.

In order to integrate tiny_http into a larger application structured around a poll loop, I've been using a patch which makes `ClientConnection` public and then builds `ClientConnection` objects from connections that I've received manually

We also needed support for `UnixStream`s, so I modified `Stream` to handle that. One complication was that `UnixStream` and `TcpStream` have different `SocketAddr` types, so I created a `PeerAddr` struct in refined_tcp_stream.rs that allows returning either type from `RefinedTcpStream::peer_addr()`