### PR TITLE
Fix RUSTSEC-2020-0031

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -212,7 +212,7 @@ impl Display for Header {
 
 /// Field of a header (eg. `Content-Type`, `Content-Length`, etc.)
 ///
-/// Comparaison between two `HeaderField`s ignores case.
+/// Comparison between two `HeaderField`s ignores case.
 #[derive(Debug, Clone)]
 pub struct HeaderField(AsciiString);
 
@@ -460,5 +460,14 @@ mod test {
 
         assert!(header.field.equiv(&"time"));
         assert!(header.value.as_str() == "20: 34");
+    }
+
+    // This tests reslstance to RUSTSEC-2020-0031: "HTTP Request smuggling
+    // through malformed Transfer Encoding headers"
+    // (https://rustsec.org/advisories/RUSTSEC-2020-0031.html).
+    #[test]
+    fn test_strict_headers() {
+        let smuggled = "Transfer-Encoding : chunked".parse::<Header>().unwrap();
+        assert!(!smuggled.field.equiv("Transfer-Encoding"));
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -239,7 +239,7 @@ impl FromStr for HeaderField {
     type Err = ();
 
     fn from_str(s: &str) -> Result<HeaderField, ()> {
-        AsciiString::from_ascii(s.trim())
+        AsciiString::from_ascii(s)
             .map(HeaderField)
             .map_err(|_| ())
     }

--- a/tests/input-tests.rs
+++ b/tests/input-tests.rs
@@ -81,3 +81,15 @@ fn unsupported_expect_header() {
     client.read_to_string(&mut content).unwrap();
     assert!(&content[9..].starts_with("417")); // 417 status code
 }
+
+#[test]
+fn invalid_header_name() {
+    let mut client = support::new_client_to_hello_world_server();
+
+    // note the space hidden in the Content-Length, which is invalid
+    (write!(client, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Type: text/plain; charset=utf8\r\nContent-Length : 5\r\n\r\nhello")).unwrap();
+
+    let mut content = String::new();
+    client.read_to_string(&mut content).unwrap();
+    assert!(&content[9..].starts_with("400 Bad Request")); // 400 status code
+}


### PR DESCRIPTION
Without this fix:

```
HTTP/1.1 400 Bad Request
Server: tiny-http (Rust)
Date: Sat,  2 Jan 2021 20:23:02 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 163

{"description":"could not read the body from the request, or could not execute the CGI program","cause":{"description":"Error while decoding chunks","cause":null}}
```

With this fix:

```
HTTP/1.1 400 Bad Request
Server: tiny-http (Rust)
Date: Sat,  9 Jan 2021 00:23:11 GMT
Content-Length: 0
```

Fixes #173.