### PR TITLE
Backport #190 for 0.6.x

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -248,7 +248,13 @@ impl FromStr for HeaderField {
     type Err = ();
 
     fn from_str(s: &str) -> Result<HeaderField, ()> {
-        AsciiString::from_ascii(s.trim()).map(HeaderField).map_err(|_| () )
+        if s.contains(char::is_whitespace) {
+            Err(())
+        } else {
+            AsciiString::from_ascii(s)
+                .map(HeaderField)
+                .map_err(|_| ())
+        }
     }
 }
 
@@ -468,5 +474,18 @@ mod test {
 
         assert!(header.field.equiv(&"time"));
         assert!(header.value.as_str() == "20: 34");
+    }
+
+    // This tests resistance to RUSTSEC-2020-0031: "HTTP Request smuggling through malformed
+    // Transfer Encoding headers" (https://rustsec.org/advisories/RUSTSEC-2020-0031.html).
+    #[test]
+    fn test_strict_headers() {
+        assert!("Transfer-Encoding : chunked".parse::<Header>().is_err());
+        assert!(" Transfer-Encoding: chunked".parse::<Header>().is_err());
+        assert!("Transfer Encoding: chunked".parse::<Header>().is_err());
+        assert!(" Transfer\tEncoding : chunked".parse::<Header>().is_err());
+        assert!("Transfer-Encoding: chunked".parse::<Header>().is_ok());
+        assert!("Transfer-Encoding: chunked ".parse::<Header>().is_ok());
+        assert!("Transfer-Encoding:   chunked ".parse::<Header>().is_ok());
     }
 }

--- a/tests/input-tests.rs
+++ b/tests/input-tests.rs
@@ -81,3 +81,15 @@ fn unsupported_expect_header() {
     client.read_to_string(&mut content).unwrap();
     assert!(&content[9..].starts_with("417"));   // 417 status code
 }
+
+#[test]
+fn invalid_header_name() {
+    let mut client = support::new_client_to_hello_world_server();
+
+    // note the space hidden in the Content-Length, which is invalid
+    (write!(client, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Type: text/plain; charset=utf8\r\nContent-Length : 5\r\n\r\nhello")).unwrap();
+
+    let mut content = String::new();
+    client.read_to_string(&mut content).unwrap();
+    assert!(&content[9..].starts_with("400 Bad Request")); // 400 status code
+}


### PR DESCRIPTION
This is a single commit backport of #190 by @therealbstern

Since a considerable number of consumers of `tiny-http` will be using Rouille, which currently targets `0.6.2`, it would be nice to have this patch released as a `0.6.3` version so that users pick it up automatically when they run `cargo update`.

GitHub won't let me express that, so please feel free to retarget this PR at a branch off the 0.6.2 tag, it should apply cleanly.

