### PR TITLE
Prevent duplicate Content-Type headers

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -268,17 +268,14 @@ where
             return;
         // if the header is Content-Type and it's already set, overwrite it
         } else if header.field.equiv(&"Content-Type") {
-            match self
+            if let Some(content_type_header) = self
                 .headers
-                .iter()
-                .position(|h| h.field.equiv(&"Content-Type"))
+                .iter_mut()
+                .find(|h| h.field.equiv("Content-Type"))
             {
-                Some(p) => {
-                    self.headers[p].value = header.value;
-                    return;
-                }
-                None => (),
-            };
+                content_type_header.value = header.value;
+                return;
+            }
         }
 
         self.headers.push(header);

--- a/src/response.rs
+++ b/src/response.rs
@@ -31,6 +31,11 @@ use std::str::FromStr;
 ///     header will be equivalent to modifying the size of the data but the header
 ///     itself may not be present in the final result.
 ///
+///  - `Content-Type`: You may only set this header to one value at a time. If you
+///     try to set it more than once, the existing value will be overwritten. This
+///     behavior differs from the default for most headers, which is to allow them to
+///     be set multiple times in the same response.
+///
 pub struct Response<R>
 where
     R: Read,
@@ -253,6 +258,19 @@ where
             }
 
             return;
+        // if the header is Content-Type and it's already set, overwrite it
+        } else if header.field.equiv(&"Content-Type") {
+            match self
+                .headers
+                .iter()
+                .position(|h| h.field.equiv(&"Content-Type"))
+            {
+                Some(p) => {
+                    self.headers[p].value = header.value;
+                    return;
+                }
+                None => (),
+            };
         }
 
         self.headers.push(header);


### PR DESCRIPTION
Fixes #134

`Response::from_string` automatically assigns `Content-Type: text/plain; charset=UTF-8`. That's fine, but if instead you want a different header value, like `application/json`, there isn't any way to do it with `from_string()`. If you call `.with_header()` and try to set it that way, you end up with two `Content-Type` headers. The only workaround at the moment is to use `Response::new()`.

Since there's already a special case in `Response::add_header` for `Content-Length`, I added another one for `Content-Type`. It checks for an existing `Content-Type` header and overwrites it with the new value. Otherwise, it behaves as before.

I considered making this the default for all headers, but it turns out that [some headers can be set more than once](https://stackoverflow.com/questions/3241326/set-more-than-one-http-header-with-the-same-name).