### PR TITLE
Small dependency optimization: Don't import "oldtime" into chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ascii = "1.0"
 chunked_transfer = "1"
 openssl = { version = "0.10", optional = true }
 url = "2"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features=["clock"] }
 log = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
It isn't used by this library. This cuts down on the number of dependencies from 28 to 27