### PR TITLE
Enable GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,80 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  clippy_rustfmt:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features
+
+#      - name: Format
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: fmt
+#          args: -- --check
+
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Build (Default Features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Build (All Features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
+  test_msrv:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install 1.41 toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.41.1
+          override: true
+
+      - name: Build (Default Features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features

--- a/tests/non-chunked-buffering.rs
+++ b/tests/non-chunked-buffering.rs
@@ -45,7 +45,7 @@ fn big_response_reader() -> Reader {
 fn identity_served<'a>(r: &'a mut Reader) -> tiny_http::Response<&'a mut Reader> {
     let body_len = r.inner.get_ref().len();
     tiny_http::Response::empty(200)
-        .with_chunked_threshold(usize::MAX)
+        .with_chunked_threshold(std::usize::MAX)
         .with_data(r, Some(body_len))
 }
 


### PR DESCRIPTION
We can run the GHA CI in parallel with Travis for as long as travis-ci.org is still available (it was supposed to be discontinued in December 2020).

This workflow also tests against a notional MSRV of 1.41.1, which is the same version that ships with Debian Stable & OldStable.

---
This doesn't handle building `cargo doc` and pushing it to pages (yet), but Travis can continue to handle that until it dies and since docs.rs/tiny-http exists now it's not quite so critical.