### PR TITLE
Make Request testing easier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ use client::ClientConnection;
 use util::MessagesQueue;
 
 pub use common::{HTTPVersion, Header, HeaderField, Method, StatusCode};
-pub use request::{ReadWrite, Request};
+pub use request::{MockRequest, ReadWrite, Request};
 pub use response::{Response, ResponseBox};
 
 mod client;

--- a/src/request.rs
+++ b/src/request.rs
@@ -72,6 +72,99 @@ pub struct Request {
     notify_when_responded: Option<Sender<()>>,
 }
 
+/// A simpler version of a `Request` that is useful for testing. No data actually goes anywhere.
+///
+/// By default, `MockRequest` pretends to be an unsecure GET request for the server root (`/`)
+/// with no headers. To create a `MockRequest` with different parameters, use the builder pattern:
+///
+/// ```
+/// let request = MockRequest::new()
+///     .with_method(Method::Post)
+///     .with_path("/api/widgets")
+///     .with_body("42");
+/// ```
+///
+/// Then, convert the `MockRequest` into a real `Request` and pass it to the server under test:
+///
+/// ```
+/// let response = server.handle_request(request.into());
+/// assert_eq!(response.status_code(), StatusCode(200));
+/// ```
+pub struct MockRequest {
+    body: &'static str,
+    remote_addr: SocketAddr,
+    // true if HTTPS, false if HTTP
+    secure: bool,
+    method: Method,
+    path: &'static str,
+    http_version: HTTPVersion,
+    headers: Vec<Header>,
+}
+
+impl From<MockRequest> for Request {
+    fn from(mock: MockRequest) -> Request {
+        new_request(
+            mock.secure,
+            mock.method,
+            mock.path.to_string(),
+            mock.http_version,
+            mock.headers,
+            mock.remote_addr,
+            mock.body.as_bytes(),
+            std::io::sink(),
+        )
+        .unwrap()
+    }
+}
+
+impl Default for MockRequest {
+    fn default() -> Self {
+        MockRequest {
+            body: "",
+            remote_addr: "0.0.0.0:0".parse().unwrap(),
+            secure: false,
+            method: Method::Get,
+            path: "/",
+            http_version: HTTPVersion::from((1, 1)),
+            headers: Vec::new(),
+        }
+    }
+}
+
+impl MockRequest {
+    pub fn new() -> Self {
+        MockRequest::default()
+    }
+    pub fn with_body(mut self, body: &'static str) -> Self {
+        self.body = body;
+        self
+    }
+    pub fn with_remote_addr(mut self, remote_addr: SocketAddr) -> Self {
+        self.remote_addr = remote_addr;
+        self
+    }
+    pub fn with_https(mut self) -> Self {
+        self.secure = true;
+        self
+    }
+    pub fn with_method(mut self, method: Method) -> Self {
+        self.method = method;
+        self
+    }
+    pub fn with_path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+    pub fn with_http_version(mut self, version: HTTPVersion) -> Self {
+        self.http_version = version;
+        self
+    }
+    pub fn with_headers(mut self, headers: Vec<Header>) -> Self {
+        self.headers = headers;
+        self
+    }
+}
+
 struct NotifyOnDrop<R> {
     sender: Sender<()>,
     inner: R,
@@ -97,6 +190,7 @@ impl<R> Drop for NotifyOnDrop<R> {
 }
 
 /// Error that can happen when building a `Request` object.
+#[derive(Debug)]
 pub enum RequestCreationError {
     /// The client sent an `Expect` header that was not recognized by tiny-http.
     ExpectationFailed,

--- a/src/request.rs
+++ b/src/request.rs
@@ -159,8 +159,8 @@ impl MockRequest {
         self.http_version = version;
         self
     }
-    pub fn with_headers(mut self, headers: Vec<Header>) -> Self {
-        self.headers = headers;
+    pub fn with_header(mut self, header: Header) -> Self {
+        self.headers.push(header);
         self
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -234,6 +234,13 @@ where
         self
     }
 
+    /// Convert the response into the underlying `Read` type.
+    ///
+    /// This is mainly useful for testing as it must consume the `Response`.
+    pub fn into_reader(self) -> R {
+        self.reader
+    }
+
     /// The current `Content-Length` threshold for switching over to
     /// chunked transfer. The default is 32768 bytes. Notice that
     /// chunked transfer is mutually exclusive with sending a
@@ -466,6 +473,11 @@ where
     /// Retrieves the current value of the `Response` data length
     pub fn data_length(&self) -> Option<usize> {
         self.data_length
+    }
+
+    /// Retrieves the current list of `Response` headers
+    pub fn headers(&self) -> &[Header] {
+        &self.headers
     }
 }
 


### PR DESCRIPTION
Fixes #189.

 - Create `MockRequest` so downstream users can build `Request`-like objects for testing without exposing `Request` too much
 - Implement a builder pattern for `MockRequest` (i.e. the user can chain methods together to build the request they want)
 - Add `into_reader()` and `headers()` to `Response` so the user can inspect test results