### PR TITLE
Fix SSL warnings

### DIFF
--- a/examples/ssl.rs
+++ b/examples/ssl.rs
@@ -35,6 +35,8 @@ fn main() {
         );
 
         let response = Response::from_string("hello world");
-        request.respond(response);
+        request
+            .respond(response)
+            .unwrap_or(println!("Failed to respond to request"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl Server {
     pub fn https<A>(
         addr: A,
         config: SslConfig,
-    ) -> Result<Server, Box<Error + Send + Sync + 'static>>
+    ) -> Result<Server, Box<dyn Error + Send + Sync + 'static>>
     where
         A: ToSocketAddrs,
     {
@@ -266,14 +266,14 @@ impl Server {
                 use openssl::ssl::SslVerifyMode;
                 use openssl::x509::X509;
 
-                let mut ctxt = try!(SslContext::builder(ssl::SslMethod::tls()));
-                try!(ctxt.set_cipher_list("DEFAULT"));
-                let certificate = try!(X509::from_pem(&config.certificate[..]));
-                try!(ctxt.set_certificate(&certificate));
-                let private_key = try!(PKey::private_key_from_pem(&config.private_key[..]));
-                try!(ctxt.set_private_key(&private_key));
+                let mut ctxt = SslContext::builder(ssl::SslMethod::tls())?;
+                ctxt.set_cipher_list("DEFAULT")?;
+                let certificate = X509::from_pem(&config.certificate[..])?;
+                ctxt.set_certificate(&certificate)?;
+                let private_key = PKey::private_key_from_pem(&config.private_key[..])?;
+                ctxt.set_private_key(&private_key)?;
                 ctxt.set_verify(SslVerifyMode::NONE);
-                try!(ctxt.check_private_key());
+                ctxt.check_private_key()?;
 
                 // let's wipe the certificate and private key from memory, because we're
                 // better safe than sorry


### PR DESCRIPTION
Compiling and testing with the `ssl` feature enabled produces several warnings. These changes correct the associated problems so the compiler no longer complains.

<details>
<summary>Click to show warnings</summary>

```
$ cargo build --features ssl
...
warning: trait objects without an explicit `dyn` are deprecated                                                                                                                                             
   --> src/lib.rs:219:29                                                                                                                                                                                    
    |                      
219 |     ) -> Result<Server, Box<Error + Send + Sync + 'static>>
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Error + Send + Sync + 'static`
    |                                                    
    = note: `#[warn(bare_trait_objects)]` on by default
               
warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:269:32                     
    |                                                 
269 |                 let mut ctxt = try!(SslContext::builder(ssl::SslMethod::tls()));
    |                                ^^^                    
    |                                   
    = note: `#[warn(deprecated)]` on by default  
                                                 
warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:270:17                                                                     
    |
270 |                 try!(ctxt.set_cipher_list("DEFAULT"));
    |                 ^^^
               
warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:271:35        
    |                         
271 |                 let certificate = try!(X509::from_pem(&config.certificate[..]));
    |                                   ^^^    
                                     
warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:272:17                                                                     
    |
272 |                 try!(ctxt.set_certificate(&certificate));
    |                 ^^^

warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:273:35
    |
273 |                 let private_key = try!(PKey::private_key_from_pem(&config.private_key[..]));
    |                                   ^^^

warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:274:17
    |
274 |                 try!(ctxt.set_private_key(&private_key));
    |                 ^^^

warning: use of deprecated macro `try`: use the `?` operator instead
   --> src/lib.rs:276:17
    |
276 |                 try!(ctxt.check_private_key());
    |                 ^^^

...
$ cargo test --features ssl
...
warning: unused `std::result::Result` that must be used                                                                                                                                                     
  --> examples/ssl.rs:38:9                                                                                                                                                                                  
   |                                                                                                                                                                                                        
38 |         request.respond(response);                                                                                                                                                                     
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |                                                                                  
   = note: `#[warn(unused_must_use)]` on by default  
   = note: this `Result` may be an `Err` variant, which should be handled
...
```

</details>