### PR TITLE
Prompt responses

### DIFF
--- a/src/util/fused_reader.rs
+++ b/src/util/fused_reader.rs
@@ -1,18 +1,22 @@
-use std::io::{Read, IoSliceMut, Result as IoResult};
+use std::io::{IoSliceMut, Read, Result as IoResult};
 
 /// Wraps another reader and provides "fused" behavior.
 /// When the underlying reader reaches EOF, it is dropped
 /// and the fused reader becomes an empty stub.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FusedReader<R: Read> {
-    inner: Option<R>
+    inner: Option<R>,
 }
 
 impl<R: Read> FusedReader<R> {
-    pub fn new(inner: R) -> Self { Self { inner: Some(inner) } }
+    pub fn new(inner: R) -> Self {
+        Self { inner: Some(inner) }
+    }
 
     #[allow(dead_code)]
-    pub fn into_inner(self) -> Option<R> { self.inner }
+    pub fn into_inner(self) -> Option<R> {
+        self.inner
+    }
 }
 
 impl<R: Read> Read for FusedReader<R> {
@@ -20,10 +24,12 @@ impl<R: Read> Read for FusedReader<R> {
         match &mut self.inner {
             Some(r) => {
                 let l = r.read(buf)?;
-                if l == 0 { self.inner = None; }
+                if l == 0 {
+                    self.inner = None;
+                }
                 Ok(l)
-            },
-            None => Ok(0)
+            }
+            None => Ok(0),
         }
     }
 
@@ -31,10 +37,12 @@ impl<R: Read> Read for FusedReader<R> {
         match &mut self.inner {
             Some(r) => {
                 let l = r.read_vectored(bufs)?;
-                if l == 0 { self.inner = None; }
+                if l == 0 {
+                    self.inner = None;
+                }
                 Ok(l)
-            },
-            None => Ok(0)
+            }
+            None => Ok(0),
         }
     }
 }

--- a/src/util/fused_reader.rs
+++ b/src/util/fused_reader.rs
@@ -1,0 +1,40 @@
+use std::io::{Read, IoSliceMut, Result as IoResult};
+
+/// Wraps another reader and provides "fused" behavior.
+/// When the underlying reader reaches EOF, it is dropped
+/// and the fused reader becomes an empty stub.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FusedReader<R: Read> {
+    inner: Option<R>
+}
+
+impl<R: Read> FusedReader<R> {
+    pub fn new(inner: R) -> Self { Self { inner: Some(inner) } }
+
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> Option<R> { self.inner }
+}
+
+impl<R: Read> Read for FusedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        match &mut self.inner {
+            Some(r) => {
+                let l = r.read(buf)?;
+                if l == 0 { self.inner = None; }
+                Ok(l)
+            },
+            None => Ok(0)
+        }
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> IoResult<usize> {
+        match &mut self.inner {
+            Some(r) => {
+                let l = r.read_vectored(bufs)?;
+                if l == 0 { self.inner = None; }
+                Ok(l)
+            },
+            None => Ok(0)
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,21 +1,21 @@
 pub use self::custom_stream::CustomStream;
 pub use self::equal_reader::EqualReader;
+pub use self::fused_reader::FusedReader;
 pub use self::messages_queue::MessagesQueue;
 pub use self::refined_tcp_stream::RefinedTcpStream;
 pub use self::sequential::{SequentialReader, SequentialReaderBuilder};
 pub use self::sequential::{SequentialWriter, SequentialWriterBuilder};
 pub use self::task_pool::TaskPool;
-pub use self::fused_reader::FusedReader;
 
 use std::str::FromStr;
 
 mod custom_stream;
 mod equal_reader;
+mod fused_reader;
 mod messages_queue;
 mod refined_tcp_stream;
 mod sequential;
 mod task_pool;
-mod fused_reader;
 
 /// Parses a the value of a header.
 /// Suitable for `Accept-*`, `TE`, etc.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,6 +5,7 @@ pub use self::refined_tcp_stream::RefinedTcpStream;
 pub use self::sequential::{SequentialReader, SequentialReaderBuilder};
 pub use self::sequential::{SequentialWriter, SequentialWriterBuilder};
 pub use self::task_pool::TaskPool;
+pub use self::fused_reader::FusedReader;
 
 use std::str::FromStr;
 
@@ -14,6 +15,7 @@ mod messages_queue;
 mod refined_tcp_stream;
 mod sequential;
 mod task_pool;
+mod fused_reader;
 
 /// Parses a the value of a header.
 /// Suitable for `Accept-*`, `TE`, etc.

--- a/tests/promptness.rs
+++ b/tests/promptness.rs
@@ -19,7 +19,9 @@ impl<'b> Read for SlowByteSrc {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         sleep(Duration::from_millis(100));
         let l = self.len.min(buf.len()).min(1000);
-        buf[..l].fill(self.val);
+        for v in buf[..l].iter_mut() {
+            *v = self.val;
+        }
         self.len -= l;
         Ok(l)
     }

--- a/tests/promptness.rs
+++ b/tests/promptness.rs
@@ -89,19 +89,6 @@ mod prompt_pipelining {
     }
 
     #[test]
-    fn expect_continue() {
-        assert_requests_parsed_promptly(5, REQ_BODY, Duration::from_millis(200), move |wr| {
-            for _ in 0..5 {
-                write!(wr, "GET / HTTP/1.1\r\n").unwrap();
-                write!(wr, "Connection: keep-alive\r\n").unwrap();
-                write!(wr, "Expect: 100 continue\r\n").unwrap();
-                write!(wr, "Content-Length: {}\r\n\r\n", REQ_BODY.len()).unwrap();
-                wr.write_all(REQ_BODY).unwrap();
-            }
-        });
-    }
-
-    #[test]
     fn chunked() {
         assert_requests_parsed_promptly(5, REQ_BODY, Duration::from_millis(200), move |wr| {
             for _ in 0..5 {

--- a/tests/promptness.rs
+++ b/tests/promptness.rs
@@ -1,0 +1,185 @@
+extern crate tiny_http;
+
+use tiny_http::{Server, Response};
+use std::net::{TcpStream, Shutdown};
+use std::io::{copy, Write, Read};
+use std::thread::{spawn, sleep};
+use std::time::Duration;
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::ops::Deref;
+
+/// Stream that produces bytes very slowly
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct SlowByteSrc { val: u8, len: usize }
+impl<'b> Read for SlowByteSrc {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        sleep(Duration::from_millis(100));
+        let l = self.len.min(buf.len()).min(1000);
+        buf[..l].fill(self.val);
+        self.len -= l;
+        Ok(l)
+    }
+}
+
+/// crude impl of http `Transfer-Encoding: chunked`
+fn encode_chunked(data: &mut dyn Read, output: &mut dyn Write) {
+    let mut buf = [0u8; 4096];
+    loop {
+        let l = data.read(&mut buf).unwrap();
+        write!(output, "{:X}\r\n", l).unwrap();
+        output.write_all(&buf[..l]).unwrap();
+        write!(output, "\r\n").unwrap();
+        if l == 0 { break; }
+    }
+}
+
+mod prompt_pipelining {
+    use super::*;
+
+    /// Check that pipelined requests on the same connection are received promptly.
+    fn assert_requests_parsed_promptly(
+        req_cnt: usize,
+        req_body: &'static [u8],
+        timeout: Duration,
+        req_writer: impl FnOnce(&mut dyn Write) + Send + 'static
+    ) {
+        let resp_body = SlowByteSrc { val: 42, len: 1000_000 }; // very slow response body
+
+        let server = Server::http("0.0.0.0:0").unwrap();
+        let mut client = TcpStream::connect(server.server_addr()).unwrap();
+        let (svr_send, svr_rcv) = channel();
+
+        spawn(move || {
+            for _ in 0..req_cnt {
+                let mut req = server.recv().unwrap();
+                // read the whole body of the request
+                let mut body = Vec::new();
+                req.as_reader().read_to_end(&mut body).unwrap();
+                assert_eq!(req_body, body.as_slice());
+                // The next pipelined request should now be available for parsing,
+                // while we send the (possibly slow) response in another thread
+                spawn(move || req.respond(
+                    Response::empty(200).with_data(resp_body, Some(resp_body.len))
+                ));
+            }
+            svr_send.send(()).unwrap();
+        });
+
+        spawn(move || req_writer(&mut client));
+
+        // requests must be sent and received quickly (before timeout expires)
+        svr_rcv.recv_timeout(timeout)
+            .expect("Server did not finish reading pipelined requests quickly enough");
+    }
+
+    // short (but not trivial) request body
+    const REQ_BODY: &'static [u8] = &[65; 5000];
+
+    #[test]
+    fn content_length() {
+        assert_requests_parsed_promptly(5, REQ_BODY, Duration::from_millis(200), move |wr| {
+            for _ in 0..5 {
+                write!(wr, "GET / HTTP/1.1\r\n").unwrap();
+                write!(wr, "Connection: keep-alive\r\n").unwrap();
+                write!(wr, "Content-Length: {}\r\n\r\n", REQ_BODY.len()).unwrap();
+                wr.write_all(REQ_BODY).unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn expect_continue() {
+        assert_requests_parsed_promptly(5, REQ_BODY, Duration::from_millis(200), move |wr| {
+            for _ in 0..5 {
+                write!(wr, "GET / HTTP/1.1\r\n").unwrap();
+                write!(wr, "Connection: keep-alive\r\n").unwrap();
+                write!(wr, "Expect: 100 continue\r\n").unwrap();
+                write!(wr, "Content-Length: {}\r\n\r\n", REQ_BODY.len()).unwrap();
+                wr.write_all(REQ_BODY).unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn chunked() {
+        assert_requests_parsed_promptly(5, REQ_BODY, Duration::from_millis(200), move |wr| {
+            for _ in 0..5 {
+                write!(wr, "GET / HTTP/1.1\r\n").unwrap();
+                write!(wr, "Connection: keep-alive\r\n").unwrap();
+                write!(wr, "Transfer-Encoding: chunked\r\n\r\n").unwrap();
+                let mut body = REQ_BODY;
+                encode_chunked(&mut body, wr);
+            }
+        });
+    }
+}
+
+mod prompt_responses {
+    use super::*;
+
+    /// Check that response is sent promptly without waiting for full request body.
+    fn assert_responds_promptly(
+        timeout: Duration,
+        req_writer: impl FnOnce(&mut dyn Write) + Send + 'static
+    ) {
+        let server = Server::http("0.0.0.0:0").unwrap();
+        let client = TcpStream::connect(server.server_addr()).unwrap();
+
+        spawn(move || loop {
+            // server attempts to respond immediately
+            let req = server.recv().unwrap();
+            req.respond(Response::empty(400)).unwrap();
+        });
+
+        let client = Arc::new(client);
+        let client_write = Arc::clone(&client);
+        // request written (possibly very slowly) in another thread
+        spawn(move || req_writer(&mut client_write.deref()));
+
+        // response should arrive quickly (before timeout expires)
+        client.set_read_timeout(Some(timeout)).unwrap();
+        let resp = client.deref().read(&mut [0u8; 4096]);
+        client.shutdown(Shutdown::Both).unwrap();
+        assert!(resp.is_ok(), "Server response was not sent promptly");
+    }
+
+    static SLOW_BODY: SlowByteSrc = SlowByteSrc { val: 65, len: 1000_000 };
+
+    #[test]
+    fn content_length_http11() {
+        assert_responds_promptly(Duration::from_millis(200), move |wr| {
+            write!(wr, "GET / HTTP/1.1\r\n").unwrap();
+            write!(wr, "Content-Length: {}\r\n\r\n", SLOW_BODY.len).unwrap();
+            copy(&mut SLOW_BODY.clone(), wr).unwrap();
+        });
+    }
+
+    #[test]
+    fn content_length_http10() {
+        assert_responds_promptly(Duration::from_millis(200), move |wr| {
+            write!(wr, "GET / HTTP/1.0\r\n").unwrap();
+            write!(wr, "Content-Length: {}\r\n\r\n", SLOW_BODY.len).unwrap();
+            copy(&mut SLOW_BODY.clone(), wr).unwrap();
+        });
+    }
+
+    #[test]
+    fn expect_continue() {
+        assert_responds_promptly(Duration::from_millis(200), move |wr| {
+            write!(wr, "GET / HTTP/1.1\r\n").unwrap();
+            write!(wr, "Expect: 100 continue\r\n").unwrap();
+            write!(wr, "Content-Length: {}\r\n\r\n", SLOW_BODY.len).unwrap();
+            copy(&mut SLOW_BODY.clone(), wr).unwrap();
+        });
+    }
+
+    #[test]
+    fn chunked() {
+        assert_responds_promptly(Duration::from_millis(200), move |wr| {
+            write!(wr, "GET / HTTP/1.1\r\n").unwrap();
+            write!(wr, "Transfer-Encoding: chunked\r\n\r\n").unwrap();
+            encode_chunked(&mut SLOW_BODY.clone(), wr);
+        });
+    }
+}


### PR DESCRIPTION
Allows the server to send responses immediately, without waiting for the full request body to arrive.

The trade-off is that the server author must explicitly read the full request body before responding if they want the next request in the pipeline to start parsing concurrently while the response is being sent.

This is intended to resolve issue #206.