### PR TITLE
Make the log dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
 
 [features]
-default = []
+default = ["log"]
 ssl = ["openssl"]
 
 [dependencies]
@@ -20,7 +20,7 @@ chunked_transfer = "1"
 openssl = { version = "0.10", optional = true }
 url = "2"
 chrono = { version = "0.4", default-features = false, features=["clock"] }
-log = "0.4"
+log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub use test::TestRequest;
 
 mod client;
 mod common;
+mod log;
 mod request;
 mod response;
 mod test;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "log")]
+pub(crate) use log::{debug, error};
+
+#[cfg(not(feature = "log"))]
+macro_rules! _debug {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(not(feature = "log"))]
+macro_rules! _error {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(not(feature = "log"))]
+pub(crate) use {_debug as debug, _error as error};


### PR DESCRIPTION
In an effort to cut down on dependencies, this makes the log dependency optional. It's turned on by default to not break existing users of the crate but with `default-features = false` this dependency disappears.