### PR TITLE
Add a convenient method getting a string from Request.

### DIFF
--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,4 +1,4 @@
-use tiny_http::{Server, Response};
+use tiny_http::{Response, Server};
 
 fn main() {
     let server = Server::http("0.0.0.0:8000").unwrap();
@@ -11,7 +11,12 @@ fn main() {
                 println!("{}", s);
                 request.respond(Response::from_string(s)).unwrap()
             }
-            Err(e) => request.respond(Response::from_string(format!("Couldn't upload data: {}", e))).unwrap()
+            Err(e) => request
+                .respond(Response::from_string(format!(
+                    "Couldn't upload data: {}",
+                    e
+                )))
+                .unwrap(),
         }
     }
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,0 +1,17 @@
+use tiny_http::{Server, Response};
+
+fn main() {
+    let server = Server::http("0.0.0.0:8000").unwrap();
+
+    for request in server.incoming_requests() {
+        let mut request = request;
+
+        match request.to_string() {
+            Ok(s) => {
+                println!("{}", s);
+                request.respond(Response::from_string(s)).unwrap()
+            }
+            Err(e) => request.respond(Response::from_string(format!("Couldn't upload data: {}", e))).unwrap()
+        }
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use std::io::{Error as IoError};
+use std::io::Error as IoError;
 use std::io::{self, Cursor, ErrorKind, Read, Write};
 
 use std::fmt;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use std::io::Error as IoError;
+use std::io::{Bytes, Error as IoError};
 use std::io::{self, Cursor, ErrorKind, Read, Write};
 
 use std::fmt;
@@ -394,6 +394,21 @@ impl Request {
             Box::new(writer) as Box<dyn Write + Send + 'static>
         } else {
             writer
+        }
+    }
+
+    /// Extract a response String from the Request.
+    ///
+    /// # Errors
+    ///
+    /// If the data in this stream is *not* valid UTF-8 then an error is
+    /// returned and `buf` is unchanged.
+    pub fn to_string(&mut self) -> Result<String, IoError> {
+        let mut buffer = String::new();
+
+        match self.as_reader().read_to_string(&mut buffer) {
+            Ok(_) => Ok(buffer),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use std::io::{Bytes, Error as IoError};
+use std::io::{Error as IoError};
 use std::io::{self, Cursor, ErrorKind, Read, Write};
 
 use std::fmt;


### PR DESCRIPTION
Here's a very simple method for making getting the string from a request a little bit easier for users, it shouldn't complicate or slow anything down as AFAIK.

- Is there a faster way I'm not seeing by not calling `as_reader`?
- Because it's only utf-8, strings should it be called `to_utf8_string` to clear up confusion with developers?

Thanks,
Grant Handy