### PR TITLE
Add option to use rustls 0.20.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,23 @@ edition = "2018"
 
 [features]
 default = []
-ssl = ["openssl"]
+ssl = ["ssl-openssl"]
+ssl-openssl = ["openssl"]
+ssl-rustls = ["rustls"]
 
 [dependencies]
 ascii = "1.0"
 chunked_transfer = "1"
-openssl = { version = "0.10", optional = true }
 url = "2"
 chrono = { version = "0.4", default-features = false, features=["clock"] }
 log = "0.4"
+
+#[cfg(feature = "ssl-openssl")]
+openssl = { version = "0.10", optional = true }
+
+#[cfg(feature = "ssl-rustls")]
+rustls = { version = "0.20", optional = true }
+rustls-pemfile = "0.2.1"
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ impl Server {
             log::debug!("Running accept thread");
             while !inside_close_trigger.load(Relaxed) {
                 let new_client = match server.accept() {
-                    Ok((mut sock, _)) => {
+                    Ok((sock, _)) => {
                         use util::RefinedTcpStream;
                         let (read_closable, write_closable) = match ssl {
                             None => {


### PR DESCRIPTION
This a minor update of #155 to use the latest version of rustls.
I think this is useful because it allows tiny-http to serve TLS on platforms that don't have OpenSSL, like OpenBSD.