### PR TITLE
Add optional serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ openssl = { version = "0.10", optional = true }
 url = "2"
 chrono = { version = "0.4", default-features = false, features=["clock"] }
 log = "0.4"
-serde = { version = "1.0.118", features = ["derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ openssl = { version = "0.10", optional = true }
 url = "2"
 chrono = { version = "0.4", default-features = false, features=["clock"] }
 log = "0.4"
+serde = { version = "1.0.118", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-use chrono::*;
+use chrono::{DateTime, Utc};
 
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,8 @@ use client::ClientConnection;
 use util::MessagesQueue;
 
 pub use common::{HTTPVersion, Header, HeaderField, Method, StatusCode};
-pub use request::{ReadWrite, Request};
-pub use response::{Response, ResponseBox};
+pub use request::{Parameters as RequestParameters, ReadWrite, Request};
+pub use response::{Parameters as ResponseParameters, Response, ResponseBox};
 pub use test::TestRequest;
 
 mod client;


### PR DESCRIPTION
Adds an optional serde feature.

I have a VM environment where the host receives HTTP requests and serializes them into the guest.

I've been carrying these patches for a while and would hope that you would consider receiving them upstream.

Comments and suggestions appreciated.