### PR TITLE
Remove chrono, use time directly, due to RUSTSEC-2020-0159

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ ascii = "1.0"
 chunked_transfer = "1"
 openssl = { version = "0.10", optional = true }
 url = "2"
-chrono = { version = "0.4", default-features = false, features=["clock"] }
 log = "0.4"
+time = { version = "0.3", features = [ "std", "formatting" ] }
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,8 +2,7 @@ use ascii::{AsciiStr, AsciiString, FromAsciiError};
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
-
-use chrono::*;
+use time::{format_description, OffsetDateTime};
 
 /// Status code of a request or response.
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Ord, PartialOrd)]
@@ -398,18 +397,25 @@ impl From<(u8, u8)> for HTTPVersion {
 /// Represents the current date, expressed in RFC 1123 format, e.g. Sun, 06 Nov 1994 08:49:37 GMT
 #[allow(clippy::upper_case_acronyms)]
 pub struct HTTPDate {
-    d: DateTime<Utc>,
+    d: OffsetDateTime,
 }
 
 impl HTTPDate {
     pub fn new() -> HTTPDate {
-        HTTPDate { d: Utc::now() }
+        HTTPDate {
+            d: OffsetDateTime::now_utc(),
+        }
     }
 }
 
 impl ToString for HTTPDate {
     fn to_string(&self) -> String {
-        self.d.format("%a, %e %b %Y %H:%M:%S GMT").to_string()
+        // Note: This can probably be made Self::format however parse is not a const function, making this difficult.
+        let format = format_description::parse("%a, %e %b %Y %H:%M:%S GMT")
+            .expect("Cannot fail.  The format string is correct.");
+        self.d
+            .format(&format)
+            .expect("Cannot fail with this format under any reasonable conditions.")
     }
 }
 


### PR DESCRIPTION
# Motivation
There is an open security issues for chrono that has been open since 2020:
- https://rustsec.org/advisories/RUSTSEC-2020-0159

Per the discussion on the chrono issue about the vulnerability, the recommended approach is to replace chrono with time 0.3:
https://github.com/chronotope/chrono/issues/602

In tiny-http the dependency is nicely encapsulated, so no users of tiny-http should be affected by this change.

# Changes
- Replace the chrono dependency with time 0.3.

# Tests
Existing tests pass, no new tests have been added.

The formatting can be compared on the rust playground with:

```
use time::{format_description, OffsetDateTime};
use chrono::{DateTime, Utc};

fn main() {
    {
      let format: Vec<format_description::FormatItem<'static>> = format_description::parse("%a, %e %b %Y %H:%M:%S GMT").unwrap();
      let date = OffsetDateTime::now_utc();
      println!("date:   {}", date.format(&format).unwrap());
    }
    {
        let date = Utc::now();
        println!("chrono: {}", date.format("%a, %e %b %Y %H:%M:%S GMT").to_string());
    }
}
```

This does currently NOT match, so this must be resolved.