### PR TITLE
Remove the 'static requirement on TestRequest::with_path

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -45,7 +45,7 @@ pub struct TestRequest {
     // true if HTTPS, false if HTTP
     secure: bool,
     method: Method,
-    path: &'static str,
+    path: String,
     http_version: HTTPVersion,
     headers: Vec<Header>,
 }
@@ -67,7 +67,7 @@ impl From<TestRequest> for Request {
         new_request(
             mock.secure,
             mock.method,
-            mock.path.to_string(),
+            mock.path,
             mock.http_version,
             mock.headers,
             Some(mock.remote_addr),
@@ -85,7 +85,7 @@ impl Default for TestRequest {
             remote_addr: "127.0.0.1:23456".parse().unwrap(),
             secure: false,
             method: Method::Get,
-            path: "/",
+            path: "/".to_string(),
             http_version: HTTPVersion::from((1, 1)),
             headers: Vec::new(),
         }
@@ -112,8 +112,8 @@ impl TestRequest {
         self.method = method;
         self
     }
-    pub fn with_path(mut self, path: &'static str) -> Self {
-        self.path = path;
+    pub fn with_path(mut self, path: &str) -> Self {
+        self.path = path.to_string();
         self
     }
     pub fn with_http_version(mut self, version: HTTPVersion) -> Self {


### PR DESCRIPTION
With `'static`, one can only use static string slices, which makes it impossible to test with urls generated at runtime, such as ones
generated by a fuzzer. We can drop the `'static` requirement to enable this use case.

This change is backwards-compatible, because it only relaxes the requirements on `with_path`, and although the type of the field changed, that field is not exposed.

This does not incur an extra copy either. The copy was already there, it only got moved out of `from` and into `with_path` now.