### PR TITLE
Use ^1 zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ time = { version = "0.3", features = [ "std", "formatting", "macros", "parsing" 
 openssl = { version = "0.10", optional = true }
 rustls = { version = "0.20", optional = true }
 rustls-pemfile = { version = "0.2.1", optional = true }
-zeroize = { version = "1.5.2", optional = true }
+zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
 rustc-serialize = "0.3"


### PR DESCRIPTION
This PR allows the dependency on `zeroize` to float amongst whatever stable version might be in use by the project including this library. Not allowing it to float leads to incompatibilities with widely-used crates like `x25519-dalek` and `rsa`, which have older versions on pre-1.5 versions of `zeroize`.