### PR TITLE
Reduce dependencies, switch to `httpdate` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ ssl-rustls = ["rustls", "rustls-pemfile", "zeroize"]
 [dependencies]
 ascii = "1.0"
 chunked_transfer = "1"
-url = "2"
 log = "0.4.4"
-time = { version = "0.3", features = [ "std", "formatting", "macros", "parsing" ] }
+httpdate = "1.0.2"
 
 openssl = { version = "0.10", optional = true }
 rustls = { version = "0.20", optional = true }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
-use crate::common::{HTTPDate, HTTPVersion, Header, StatusCode};
-
+use crate::common::{HTTPVersion, Header, StatusCode};
+use httpdate::HttpDate;
 use std::cmp::Ordering;
 use std::sync::mpsc::Receiver;
 
@@ -9,6 +9,7 @@ use std::io::{self, Cursor, Read, Write};
 use std::fs::File;
 
 use std::str::FromStr;
+use std::time::SystemTime;
 
 /// Object representing an HTTP response whose purpose is to be given to a `Request`.
 ///
@@ -71,7 +72,7 @@ impl FromStr for TransferEncoding {
 
 /// Builds a Date: header with the current date.
 fn build_date_header() -> Header {
-    let d = HTTPDate::new();
+    let d = HttpDate::from(SystemTime::now());
     Header::from_bytes(&b"Date"[..], &d.to_string().into_bytes()[..]).unwrap()
 }
 


### PR DESCRIPTION
Goes from 18 to 5 dependencies