### PR TITLE
Make the log dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
 
 [features]
-default = []
+default = ["log"]
 ssl = ["ssl-openssl"]
 ssl-openssl = ["openssl", "zeroize"]
 ssl-rustls = ["rustls", "rustls-pemfile", "zeroize"]
@@ -19,9 +19,9 @@ ssl-rustls = ["rustls", "rustls-pemfile", "zeroize"]
 [dependencies]
 ascii = "1.0"
 chunked_transfer = "1"
-log = "0.4.4"
 httpdate = "1.0.2"
 
+log = { version = "0.4.4", optional = true }
 openssl = { version = "0.10", optional = true }
 rustls = { version = "0.20", optional = true }
 rustls-pemfile = { version = "0.2.1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ pub use test::TestRequest;
 mod client;
 mod common;
 mod connection;
+mod log;
 mod request;
 mod response;
 mod ssl;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "log")]
+pub(crate) use log::{debug, error};
+
+#[cfg(not(feature = "log"))]
+macro_rules! _debug {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(not(feature = "log"))]
+macro_rules! _error {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(not(feature = "log"))]
+pub(crate) use {_debug as debug, _error as error};


### PR DESCRIPTION
This is a rebased version of https://github.com/tiny-http/tiny-http/pull/210.