### PR TITLE
Add ssl-native-tls feature allowing using native-tls as an SSL backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
           - default
           - ssl-openssl
           - ssl-rustls
+          - ssl-native-tls
     steps:
       - uses: actions/checkout@v2
       - name: Install stable toolchain
@@ -43,6 +44,7 @@ jobs:
           - default
           - ssl-openssl
           - ssl-rustls
+          - ssl-native-tls
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - 1.56
+          - 1.57
         features:
           - default
           - ssl-openssl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = ["log"]
 ssl = ["ssl-openssl"]
 ssl-openssl = ["openssl", "zeroize"]
 ssl-rustls = ["rustls", "rustls-pemfile", "zeroize"]
+ssl-native-tls = ["native-tls", "zeroize"]
 
 [dependencies]
 ascii = "1.0"
@@ -26,6 +27,7 @@ openssl = { version = "0.10", optional = true }
 rustls = { version = "0.20", optional = true }
 rustls-pemfile = { version = "0.2.1", optional = true }
 zeroize = { version = "1", optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["http", "server", "web"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
+rust-version = "1.57"
 
 [features]
 default = ["log"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What does **tiny-http** handle?
  - Accepting and managing connections to the clients
  - Parsing requests
  - Requests pipelining
- - HTTPS (using either OpenSSL or Rustls)
+ - HTTPS (using either OpenSSL, Rustls or native-tls)
  - Transfer-Encoding and Content-Encoding
  - Turning user input (eg. POST input) into a contiguous UTF-8 string (**not implemented yet**)
  - Ranges (**not implemented yet**)

--- a/examples/ssl.rs
+++ b/examples/ssl.rs
@@ -1,11 +1,19 @@
 extern crate tiny_http;
 
-#[cfg(not(any(feature = "ssl-openssl", feature = "ssl-rustls")))]
+#[cfg(not(any(
+    feature = "ssl-openssl",
+    feature = "ssl-rustls",
+    feature = "ssl-native-tls"
+)))]
 fn main() {
     println!("This example requires one of the supported `ssl-*` features to be enabled");
 }
 
-#[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+#[cfg(any(
+    feature = "ssl-openssl",
+    feature = "ssl-rustls",
+    feature = "ssl-native-tls"
+))]
 fn main() {
     use tiny_http::{Response, Server};
 

--- a/src/ssl.rs
+++ b/src/ssl.rs
@@ -18,3 +18,10 @@ pub(crate) mod rustls;
 pub(crate) use self::rustls::RustlsContext as SslContextImpl;
 #[cfg(feature = "ssl-rustls")]
 pub(crate) use self::rustls::RustlsStream as SslStream;
+
+#[cfg(feature = "ssl-native-tls")]
+pub(crate) mod native_tls;
+#[cfg(feature = "ssl-native-tls")]
+pub(crate) use self::native_tls::NativeTlsContext as SslContextImpl;
+#[cfg(feature = "ssl-native-tls")]
+pub(crate) use self::native_tls::NativeTlsStream as SslStream;

--- a/src/ssl/native_tls.rs
+++ b/src/ssl/native_tls.rs
@@ -1,0 +1,84 @@
+use crate::connection::Connection;
+use crate::util::refined_tcp_stream::Stream as RefinedStream;
+use std::error::Error;
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr};
+use std::sync::{Arc, Mutex};
+use zeroize::Zeroizing;
+
+/// A wrapper around a `native_tls` stream.
+///
+/// Uses an internal Mutex to permit disparate reader & writer threads to access the stream independently.
+#[derive(Clone)]
+pub(crate) struct NativeTlsStream(Arc<Mutex<native_tls::TlsStream<Connection>>>);
+
+// These struct methods form the implict contract for swappable TLS implementations
+impl NativeTlsStream {
+    pub(crate) fn peer_addr(&mut self) -> std::io::Result<Option<SocketAddr>> {
+        self.0
+            .lock()
+            .expect("Failed to lock SSL stream mutex")
+            .get_mut()
+            .peer_addr()
+    }
+
+    pub(crate) fn shutdown(&mut self, how: Shutdown) -> std::io::Result<()> {
+        self.0
+            .lock()
+            .expect("Failed to lock SSL stream mutex")
+            .get_mut()
+            .shutdown(how)
+    }
+}
+
+impl Read for NativeTlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("Failed to lock SSL stream mutex")
+            .read(buf)
+    }
+}
+
+impl Write for NativeTlsStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("Failed to lock SSL stream mutex")
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0
+            .lock()
+            .expect("Failed to lock SSL stream mutex")
+            .flush()
+    }
+}
+
+pub(crate) struct NativeTlsContext(native_tls::TlsAcceptor);
+
+impl NativeTlsContext {
+    pub fn from_pem(
+        certificates: Vec<u8>,
+        private_key: Zeroizing<Vec<u8>>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let identity = native_tls::Identity::from_pkcs8(&certificates, &private_key)?;
+        let acceptor = native_tls::TlsAcceptor::new(identity)?;
+        Ok(Self(acceptor))
+    }
+
+    pub fn accept(
+        &self,
+        stream: Connection,
+    ) -> Result<NativeTlsStream, Box<dyn Error + Send + Sync + 'static>> {
+        let stream = self.0.accept(stream)?;
+        Ok(NativeTlsStream(Arc::new(Mutex::new(stream))))
+    }
+}
+
+impl From<NativeTlsStream> for RefinedStream {
+    fn from(stream: NativeTlsStream) -> Self {
+        RefinedStream::Https(stream)
+    }
+}

--- a/src/util/refined_tcp_stream.rs
+++ b/src/util/refined_tcp_stream.rs
@@ -3,12 +3,20 @@ use std::io::{Read, Write};
 use std::net::{Shutdown, SocketAddr};
 
 use crate::connection::Connection;
-#[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+#[cfg(any(
+    feature = "ssl-openssl",
+    feature = "ssl-rustls",
+    feature = "ssl-native-tls"
+))]
 use crate::ssl::SslStream;
 
 pub(crate) enum Stream {
     Http(Connection),
-    #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+    #[cfg(any(
+        feature = "ssl-openssl",
+        feature = "ssl-rustls",
+        feature = "ssl-native-tls"
+    ))]
     Https(SslStream),
 }
 
@@ -16,7 +24,11 @@ impl Clone for Stream {
     fn clone(&self) -> Self {
         match self {
             Stream::Http(tcp_stream) => Stream::Http(tcp_stream.try_clone().unwrap()),
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(ssl_stream) => Stream::Https(ssl_stream.clone()),
         }
     }
@@ -32,7 +44,11 @@ impl Stream {
     fn secure(&self) -> bool {
         match self {
             Stream::Http(_) => false,
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(_) => true,
         }
     }
@@ -40,7 +56,11 @@ impl Stream {
     fn peer_addr(&mut self) -> IoResult<Option<SocketAddr>> {
         match self {
             Stream::Http(tcp_stream) => tcp_stream.peer_addr(),
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(ssl_stream) => ssl_stream.peer_addr(),
         }
     }
@@ -48,7 +68,11 @@ impl Stream {
     fn shutdown(&mut self, how: Shutdown) -> IoResult<()> {
         match self {
             Stream::Http(tcp_stream) => tcp_stream.shutdown(how),
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(ssl_stream) => ssl_stream.shutdown(how),
         }
     }
@@ -58,7 +82,11 @@ impl Read for Stream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         match self {
             Stream::Http(tcp_stream) => tcp_stream.read(buf),
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(ssl_stream) => ssl_stream.read(buf),
         }
     }
@@ -68,7 +96,11 @@ impl Write for Stream {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         match self {
             Stream::Http(tcp_stream) => tcp_stream.write(buf),
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(ssl_stream) => ssl_stream.write(buf),
         }
     }
@@ -76,7 +108,11 @@ impl Write for Stream {
     fn flush(&mut self) -> IoResult<()> {
         match self {
             Stream::Http(tcp_stream) => tcp_stream.flush(),
-            #[cfg(any(feature = "ssl-openssl", feature = "ssl-rustls"))]
+            #[cfg(any(
+                feature = "ssl-openssl",
+                feature = "ssl-rustls",
+                feature = "ssl-native-tls"
+            ))]
             Stream::Https(ssl_stream) => ssl_stream.flush(),
         }
     }


### PR DESCRIPTION
Closes #240.
native-tls is a crate that will pick the platforms native TLS implementation depending on the chosen build target
