### PR TITLE
Added section for running examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ for request in server.incoming_requests() {
 }
 ```
 
+#### Running Included Examples
+
+1. Clone this repository locally
+2. to run an example in the examples folder run:
+```bash
+cargo run --example [example_name]
+```
+
+example:
+```bash
+cargo run --example hello-world
+```
+
+
 ### Speed
 
 Tiny-http was designed with speed in mind:
@@ -73,7 +87,7 @@ Tiny-http was designed with speed in mind:
  - Decoding the client's request is done lazily. If you don't read the request's body, it will not
  be decoded.
 
-### Examples
+### Example Implementations
 
 Examples of tiny-http in use:
 


### PR DESCRIPTION
I think the use of example in the readme was confusing as there are example implementations and examples of how tiny-http is being used in other projects. I added a sub section for running the included examples and edited the name of examples of tiny-http use in other projects. 