### PR TITLE
Add `#[must_use]` to `Response` struct

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -37,6 +37,7 @@ use std::time::SystemTime;
 ///     behavior differs from the default for most headers, which is to allow them to
 ///     be set multiple times in the same response.
 ///
+#[must_use]
 pub struct Response<R> {
     reader: R,
     status_code: StatusCode,


### PR DESCRIPTION
(feel free to close if you disagree with me that this is a desirable feature)

I just had a bug-hunting session that resulted in me accidentally writing code:

```rust
fn handle_request(request: Request) {
    if <"If-None-Match" header with matching ETag was sent> {
        Response::empty(304);
    }
    request.respond(Response::new(..)).unwrap();
}
```

when I meant to write the code:

```rust
fn handle_request(request: Request) {
    if <"If-None-Match" header with matching ETag was sent> {
        request.respond(Response::empty(304)).unwrap();
        return;
    }
    request.respond(Response::new(..)).unwrap();
}
```

This attribute will prevent that from happening (though it is backwards-incompatible, so this probably should wait for the next major release).