### PR TITLE
Listen config parser

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -162,6 +162,20 @@ impl FromStr for ConfigListenAddr {
     }
 }
 
+pub trait ToConfigListenAddr {
+    type Err;
+
+    fn to_config_listen_addr(self) -> Result<ConfigListenAddr, Self::Err> where Self: Sized;
+}
+
+impl ToConfigListenAddr for ConfigListenAddr {
+    type Err = ();
+
+    fn to_config_listen_addr(self) -> Result<ConfigListenAddr, Self::Err> {
+        Ok(self)
+    }
+}
+
 /// Unified listen socket address. Either a [`SocketAddr`] or [`std::os::unix::net::SocketAddr`].
 #[derive(Debug, Clone)]
 pub enum ListenAddr {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -157,7 +157,9 @@ impl FromStr for ConfigListenAddr {
                 Err("Unix sockets not supported on this platform".to_string())
             }
         } else {
-            Ok(ConfigListenAddr::IP(s.to_socket_addrs().map_err(|e| format!("{e}"))?.collect()))
+            Ok(ConfigListenAddr::IP(
+                s.to_socket_addrs().map_err(|e| format!("{e}"))?.collect(),
+            ))
         }
     }
 }
@@ -165,7 +167,9 @@ impl FromStr for ConfigListenAddr {
 pub trait ToConfigListenAddr {
     type Err;
 
-    fn to_config_listen_addr(self) -> Result<ConfigListenAddr, Self::Err> where Self: Sized;
+    fn to_config_listen_addr(self) -> Result<ConfigListenAddr, Self::Err>
+    where
+        Self: Sized;
 }
 
 impl ToConfigListenAddr for ConfigListenAddr {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -176,6 +176,22 @@ impl ToConfigListenAddr for ConfigListenAddr {
     }
 }
 
+impl ToConfigListenAddr for &str {
+    type Err = String;
+
+    fn to_config_listen_addr(self) -> Result<ConfigListenAddr, Self::Err> {
+        self.parse()
+    }
+}
+
+impl ToConfigListenAddr for &String {
+    type Err = String;
+
+    fn to_config_listen_addr(self) -> Result<ConfigListenAddr, Self::Err> {
+        self.parse()
+    }
+}
+
 /// Unified listen socket address. Either a [`SocketAddr`] or [`std::os::unix::net::SocketAddr`].
 #[derive(Debug, Clone)]
 pub enum ListenAddr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ use connection::Connection;
 use util::MessagesQueue;
 
 pub use common::{HTTPVersion, Header, HeaderField, Method, StatusCode};
-pub use connection::{ConfigListenAddr, ListenAddr, Listener};
+pub use connection::{ConfigListenAddr, ListenAddr, Listener, ToConfigListenAddr};
 pub use request::{ReadWrite, Request};
 pub use response::{Response, ResponseBox};
 pub use test::TestRequest;

--- a/tests/simple-test.rs
+++ b/tests/simple-test.rs
@@ -1,6 +1,7 @@
 extern crate tiny_http;
 
 use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 #[allow(dead_code)]
 mod support;
@@ -26,4 +27,30 @@ fn basic_handling() {
     let mut content = String::new();
     stream.read_to_string(&mut content).unwrap();
     assert!(content.ends_with("hello world"));
+}
+
+#[test]
+fn parse_v4_literal() {
+    let addr: tiny_http::ConfigListenAddr = "127.0.0.1:8080".parse().unwrap();
+
+    match addr {
+        tiny_http::ConfigListenAddr::IP(v) => {
+            assert_eq!(1, v.len());
+            assert_eq!(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080), *v.first().unwrap());
+        },
+        _ => panic!("Not an IP listener"),
+    }
+}
+
+#[test]
+fn parse_v6_literal() {
+    let addr: tiny_http::ConfigListenAddr = "[2001:db8::1]:8080".parse().unwrap();
+
+    match addr {
+        tiny_http::ConfigListenAddr::IP(v) => {
+            assert_eq!(1, v.len());
+            assert_eq!(SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)), 8080), *v.first().unwrap());
+        },
+        _ => panic!("Not an IP listener"),
+    }
 }

--- a/tests/simple-test.rs
+++ b/tests/simple-test.rs
@@ -36,8 +36,11 @@ fn parse_v4_literal() {
     match addr {
         tiny_http::ConfigListenAddr::IP(v) => {
             assert_eq!(1, v.len());
-            assert_eq!(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080), *v.first().unwrap());
-        },
+            assert_eq!(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
+                *v.first().unwrap()
+            );
+        }
         _ => panic!("Not an IP listener"),
     }
 }
@@ -49,8 +52,14 @@ fn parse_v6_literal() {
     match addr {
         tiny_http::ConfigListenAddr::IP(v) => {
             assert_eq!(1, v.len());
-            assert_eq!(SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)), 8080), *v.first().unwrap());
-        },
+            assert_eq!(
+                SocketAddr::new(
+                    IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                    8080
+                ),
+                *v.first().unwrap()
+            );
+        }
         _ => panic!("Not an IP listener"),
     }
 }

--- a/tests/unix-test.rs
+++ b/tests/unix-test.rs
@@ -42,3 +42,13 @@ fn unix_basic_handling() {
     client.read_to_string(&mut content).unwrap();
     assert!(content.ends_with("hello world"));
 }
+
+#[test]
+fn unix_listen_addr_parsing() {
+    let addr: tiny_http::ConfigListenAddr = "unix:/tmp/something.sock".parse().unwrap();
+
+    match addr {
+        tiny_http::ConfigListenAddr::Unix(p) => assert_eq!(p, Path::new("/tmp/something.sock")),
+        _ => panic!("Not a Unix ListenAddr"),
+    };
+}


### PR DESCRIPTION
This PR implements some "helper" code for projects that build on tiny-http, by providing functionality that can parse a string to produce a ConfigListenAddr.  In particular, it differentiates between IP (`<IP|host>:<port>`) and Unix sockets (on platforms that support them; `unix:<path>`), as the Unix socket use case is important for my work.