### PR TITLE
derive for Header and HeaderField: PartialEq, Eq, PartialOrd, Ord

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -148,7 +148,7 @@ impl PartialOrd<StatusCode> for u16 {
 }
 
 /// Represents a HTTP header.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Header {
     pub field: HeaderField,
     pub value: AsciiString,

--- a/src/common.rs
+++ b/src/common.rs
@@ -148,7 +148,7 @@ impl PartialOrd<StatusCode> for u16 {
 }
 
 /// Represents a HTTP header.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Header {
     pub field: HeaderField,
     pub value: AsciiString,
@@ -203,7 +203,7 @@ impl Display for Header {
 /// Field of a header (eg. `Content-Type`, `Content-Length`, etc.)
 ///
 /// Comparison between two `HeaderField`s ignores case.
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HeaderField(AsciiString);
 
 impl HeaderField {


### PR DESCRIPTION
I've noticed that `AsciiString` derives `PartialEq, Eq, PartialOrd, Ord` but `Header` and `HeaderField` do not.
I've been using `Header` in one of my own structs and would like to have the ability to `assert_eq!()` two of my struct containing a `Header`.

Sorry for first creating [this issue](https://github.com/tiny-http/tiny-http/issues/269). I've since learned that my account had been wrongfully flagged and resolved this issue with the GitHub support.