### PR TITLE
Get CI passing again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.60"
         features:
           - default
           - ssl-openssl
@@ -64,3 +63,24 @@ jobs:
         with:
           command: test
           args: --features ${{ matrix.features }}
+
+  msrv_test:
+    name: Build & Test on MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.60"
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,29 +1,17 @@
 on: [push, pull_request]
 name: CI
 jobs:
-  clippy_rustfmt:
-    name: Lint & Format
+  rustfmt:
+    name: Formatting
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - default
-          - ssl-openssl
-          - ssl-rustls
-          - ssl-native-tls
     steps:
       - uses: actions/checkout@v2
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
-
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features ${{ matrix.features }}
+          override: true
+          components: rustfmt
 
       - name: Format
         uses: actions-rs/cargo@v1
@@ -31,8 +19,8 @@ jobs:
           command: fmt
           args: -- --check
 
-  test:
-    name: Build & Test
+  build_test_lint:
+    name: Build, Test, and Lints
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,6 +39,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -64,7 +53,13 @@ jobs:
           command: test
           args: --features ${{ matrix.features }}
 
-  msrv_test:
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features ${{ matrix.features }}
+
+  msrv_build:
     name: Build & Test on MSRV
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - 1.57
+          - "1.60"
         features:
           - default
           - ssl-openssl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["http", "server", "web"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [features]
 default = ["log"]


### PR DESCRIPTION
This gets CI to where it's passing again [(example run)](https://github.com/CosmicHorrorDev/tiny-http/actions/runs/11830708177)

Notably the MSRV had to be bumped due to dependencies raising their MSRVs and the lack of an MSRV-aware resolver. I also moved the MSRV checking to it's own, more minimal, CI job that only takes into account building and testing with the default feature set since that's how MSRVs are usually handled

Finally dd09d10c12984a45919e9d8ff8447cca0e590ff4 moves linting into the standard _build the whole app_ job. That just leaves formatting in its own job, so I dropped the feature matrix since it doesn't impact formatting

In the end all of that leaves 10 jobs now compared to the previous 16 