### PR TITLE
Don't panic on `drop`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.60"
         features:
           - default
           - ssl-openssl
@@ -64,3 +63,24 @@ jobs:
         with:
           command: test
           args: --features ${{ matrix.features }}
+
+  msrv_test:
+    name: Build & Test on MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.60"
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,29 +1,17 @@
 on: [push, pull_request]
 name: CI
 jobs:
-  clippy_rustfmt:
-    name: Lint & Format
+  rustfmt:
+    name: Formatting
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - default
-          - ssl-openssl
-          - ssl-rustls
-          - ssl-native-tls
     steps:
       - uses: actions/checkout@v2
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
-
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features ${{ matrix.features }}
+          override: true
+          components: rustfmt
 
       - name: Format
         uses: actions-rs/cargo@v1
@@ -31,8 +19,8 @@ jobs:
           command: fmt
           args: -- --check
 
-  test:
-    name: Build & Test
+  build_test_lint:
+    name: Build, Test, and Lints
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,6 +39,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -64,7 +53,13 @@ jobs:
           command: test
           args: --features ${{ matrix.features }}
 
-  msrv_test:
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features ${{ matrix.features }}
+
+  msrv_build:
     name: Build & Test on MSRV
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - 1.57
+          - "1.60"
         features:
           - default
           - ssl-openssl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["http", "server", "web"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [features]
 default = ["log"]

--- a/src/request.rs
+++ b/src/request.rs
@@ -96,7 +96,7 @@ impl<R: Write> Write for NotifyOnDrop<R> {
 }
 impl<R> Drop for NotifyOnDrop<R> {
     fn drop(&mut self) {
-        self.sender.send(()).unwrap();
+        let _ = self.sender.send(());
     }
 }
 
@@ -491,7 +491,7 @@ impl Drop for Request {
             let response = Response::empty(500);
             let _ = self.respond_impl(response); // ignoring any potential error
             if let Some(sender) = self.notify_when_responded.take() {
-                sender.send(()).unwrap();
+                let _ = sender.send(());
             }
         }
     }

--- a/src/util/sequential.rs
+++ b/src/util/sequential.rs
@@ -156,8 +156,9 @@ where
                 self.next.send(reader).ok();
             }
             SequentialReaderInner::Waiting(recv) => {
-                let reader = recv.recv().unwrap();
-                self.next.send(reader).ok();
+                if let Ok(reader) = recv.recv() {
+                    self.next.send(reader).ok();
+                }
             }
             SequentialReaderInner::Empty => (),
         }


### PR DESCRIPTION
_Builds on top of #274_

This avoids panicking on drop as recommended by [`Drop::drop()`'s docs](https://doc.rust-lang.org/std/ops/trait.Drop.html#panics) to avoid potentially double panicking leading to an abort