### PR TITLE
Switch benches to use `divan`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.60"
         features:
           - default
           - ssl-openssl
@@ -64,3 +63,24 @@ jobs:
         with:
           command: test
           args: --features ${{ matrix.features }}
+
+  msrv_test:
+    name: Build & Test on MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.60"
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,29 +1,17 @@
 on: [push, pull_request]
 name: CI
 jobs:
-  clippy_rustfmt:
-    name: Lint & Format
+  rustfmt:
+    name: Formatting
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - default
-          - ssl-openssl
-          - ssl-rustls
-          - ssl-native-tls
     steps:
       - uses: actions/checkout@v2
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
-
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features ${{ matrix.features }}
+          override: true
+          components: rustfmt
 
       - name: Format
         uses: actions-rs/cargo@v1
@@ -31,8 +19,8 @@ jobs:
           command: fmt
           args: -- --check
 
-  test:
-    name: Build & Test
+  build_test_lint:
+    name: Build, Test, and Lints
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,6 +39,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -64,7 +53,13 @@ jobs:
           command: test
           args: --features ${{ matrix.features }}
 
-  msrv_test:
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features ${{ matrix.features }}
+
+  msrv_build:
     name: Build & Test on MSRV
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - 1.57
+          - "1.60"
         features:
           - default
           - ssl-openssl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,12 @@ jobs:
           command: test
           args: --features ${{ matrix.features }}
 
+      - name: Test Benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --features ${{ matrix.features }} -- --test
+
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.60"
+          toolchain: "1.80"
           override: true
 
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["http", "server", "web"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [features]
 default = ["log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,12 @@ native-tls = { version = "0.2", optional = true }
 rustc-serialize = "0.3"
 sha1 = "0.6.0"
 fdlimit = "0.1"
+divan = { version = "0.1.16", default-features = false }
 
 [package.metadata.docs.rs]
 # Enable just one SSL implementation
 features = ["ssl-openssl"]
+
+[[bench]]
+name = "bench"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["http", "server", "web"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tiny-http/tiny-http"
 edition = "2018"
-rust-version = "1.60"
+rust-version = "1.80"
 
 [features]
 default = ["log"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,12 +1,20 @@
-#![feature(test)]
-
 extern crate fdlimit;
-extern crate test;
 extern crate tiny_http;
 
+use divan::counter::ItemsCount;
+use divan::{bench, Bencher, Divan};
 use std::io::Write;
 use std::process::Command;
+use std::time::Duration;
 use tiny_http::Method;
+
+fn main() {
+    // Run registered benchmarks
+    Divan::default()
+        .min_time(Duration::from_secs(2))
+        .config_with_args()
+        .main();
+}
 
 #[test]
 #[ignore]
@@ -29,13 +37,13 @@ fn curl_bench() {
 }
 
 #[bench]
-fn sequential_requests(bencher: &mut test::Bencher) {
+fn sequential_requests(bencher: Bencher) {
     let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().to_ip().unwrap().port();
 
     let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
 
-    bencher.iter(|| {
+    bencher.bench_local(|| {
         (write!(stream, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")).unwrap();
 
         let request = server.recv().unwrap();
@@ -47,13 +55,13 @@ fn sequential_requests(bencher: &mut test::Bencher) {
 }
 
 #[bench]
-fn parallel_requests(bencher: &mut test::Bencher) {
+fn parallel_requests(bencher: Bencher) {
     fdlimit::raise_fd_limit();
 
     let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
     let port = server.server_addr().to_ip().unwrap().port();
 
-    bencher.iter(|| {
+    bencher.counter(ItemsCount::new(num_requests)).bench(|| {
         let mut streams = Vec::new();
 
         for _ in 0..1000usize {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,6 +4,7 @@ extern crate tiny_http;
 use divan::counter::ItemsCount;
 use divan::{bench, Bencher, Divan};
 use std::io::Write;
+use std::net;
 use std::time::Duration;
 use tiny_http::Method;
 
@@ -37,13 +38,13 @@ fn curl_bench() {
 
 #[bench]
 fn sequential_requests(bencher: Bencher) {
-    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
+    let server = tiny_http::Server::http((net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
     let port = server.server_addr().to_ip().unwrap().port();
 
-    let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+    let mut stream = net::TcpStream::connect((net::Ipv4Addr::LOCALHOST, port)).unwrap();
 
     bencher.bench_local(|| {
-        (write!(stream, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")).unwrap();
+        write!(stream, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n").unwrap();
 
         let request = server.recv().unwrap();
 
@@ -59,28 +60,23 @@ fn sequential_requests(bencher: Bencher) {
 fn parallel_requests(bencher: Bencher) {
     fdlimit::raise_fd_limit();
 
-    let server = tiny_http::Server::http("0.0.0.0:0").unwrap();
+    let server = tiny_http::Server::http((net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
     let port = server.server_addr().to_ip().unwrap().port();
 
     bencher.counter(ItemsCount::new(num_requests)).bench(|| {
         let mut streams = Vec::new();
 
         for _ in 0..1000usize {
-            let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
-            (write!(
+            let mut stream = net::TcpStream::connect((net::Ipv4Addr::LOCALHOST, port)).unwrap();
+            write!(
                 stream,
                 "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-            ))
+            )
             .unwrap();
             streams.push(stream);
         }
 
-        loop {
-            let request = match server.try_recv().unwrap() {
-                None => break,
-                Some(rq) => rq,
-            };
-
+        while let Some(request) = server.try_recv().unwrap() {
             assert_eq!(request.method(), &Method::Get);
 
             request

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,6 @@ extern crate tiny_http;
 use divan::counter::ItemsCount;
 use divan::{bench, Bencher, Divan};
 use std::io::Write;
-use std::process::Command;
 use std::time::Duration;
 use tiny_http::Method;
 
@@ -24,7 +23,7 @@ fn curl_bench() {
     let port = server.server_addr().to_ip().unwrap().port();
     let num_requests = 10usize;
 
-    match Command::new("curl")
+    match std::process::Command::new("curl")
         .arg("-s")
         .arg(format!("http://localhost:{}/?[1-{}]", port, num_requests))
         .output()
@@ -50,7 +49,9 @@ fn sequential_requests(bencher: Bencher) {
 
         assert_eq!(request.method(), &Method::Get);
 
-        request.respond(tiny_http::Response::new_empty(tiny_http::StatusCode(204)));
+        request
+            .respond(tiny_http::Response::new_empty(tiny_http::StatusCode(204)))
+            .unwrap();
     });
 }
 
@@ -82,7 +83,9 @@ fn parallel_requests(bencher: Bencher) {
 
             assert_eq!(request.method(), &Method::Get);
 
-            request.respond(tiny_http::Response::new_empty(tiny_http::StatusCode(204)));
+            request
+                .respond(tiny_http::Response::new_empty(tiny_http::StatusCode(204)))
+                .unwrap();
         }
     });
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -56,8 +56,8 @@ fn sequential_requests(bencher: Bencher) {
     });
 }
 
-#[bench]
-fn parallel_requests(bencher: Bencher) {
+#[bench(args = [10, 100, 1000])]
+fn parallel_requests(bencher: Bencher, num_requests: u64) {
     fdlimit::raise_fd_limit();
 
     let server = tiny_http::Server::http((net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
@@ -66,7 +66,7 @@ fn parallel_requests(bencher: Bencher) {
     bencher.counter(ItemsCount::new(num_requests)).bench(|| {
         let mut streams = Vec::new();
 
-        for _ in 0..1000usize {
+        for _ in 0..num_requests {
             let mut stream = net::TcpStream::connect((net::Ipv4Addr::LOCALHOST, port)).unwrap();
             write!(
                 stream,


### PR DESCRIPTION
_Builds on top of #274 to get CI passing_

TODO(cosmic): this PR bumps the MSRV up to 1.80 because the MSRV CI job is currently using `cargo test` instead of `cargo check`. Fix that at some point...

---

Switches from using the unstable `test` feature to using the [`divan` crate](https://crates.io/crates/divan) to run the benchmarks. The [`criterion` crate](https://crates.io/crates/criterion) is another popular alternative, but I prefer `divan` because it's a lot lighter in general

I also took the liberty of expanding the `parallel_requests` benchmark to run over a variety of number of requests instead of just 1000

### Current output

```console
$ cargo +nightly bench
... elided output
     Running benches/bench.rs (/home/wintermute/Programming/Repos/tiny-http/target/release/deps/bench-24b4c6b2c2a1c0fd)

running 3 tests
test curl_bench ... ignored
test parallel_requests   ... bench:  25,626,822.00 ns/iter (+/- 2,548,371.96)
test sequential_requests ... bench:      11,130.42 ns/iter (+/- 2,081.80)

test result: ok. 0 passed; 0 failed; 1 ignored; 2 measured; 0 filtered out; finished in 8.04s
```

### This PR

```console
$ cargo bench
... elided output
     Running benches/bench.rs (target/release/deps/bench-037f89c3c1b9dbe1)
Timer precision: 13 ns
bench                   fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ parallel_requests                  │               │               │               │         │
│  ├─ 10                197.9 µs      │ 643.7 µs      │ 230.1 µs      │ 235.3 µs      │ 8456    │ 8456
│  │                    50.51 Kitem/s │ 15.53 Kitem/s │ 43.44 Kitem/s │ 42.48 Kitem/s │         │
│  ├─ 100               2.046 ms      │ 24.69 ms      │ 2.3 ms        │ 2.361 ms      │ 847     │ 847
│  │                    48.87 Kitem/s │ 4.048 Kitem/s │ 43.45 Kitem/s │ 42.34 Kitem/s │         │
│  ╰─ 1000              23.56 ms      │ 64.15 ms      │ 24.89 ms      │ 25.62 ms      │ 100     │ 100
│                       42.43 Kitem/s │ 15.58 Kitem/s │ 40.16 Kitem/s │ 39.02 Kitem/s │         │
╰─ sequential_requests  9.823 µs      │ 472.1 ms      │ 10.8 µs       │ 55.34 µs      │ 38009   │ 38009
```