### PR TITLE
fix: Make sure that the connection is indeed closed at the end of request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,13 +348,17 @@ impl Server {
                             Some(ref _ssl) => unreachable!(),
                         };
 
-                        Ok(ClientConnection::new(write_closable, read_closable))
+                        Ok((
+                            write_closable.clone(),
+                            read_closable.clone(),
+                            ClientConnection::new(write_closable, read_closable),
+                        ))
                     }
                     Err(e) => Err(e),
                 };
 
                 match new_client {
-                    Ok(client) => {
+                    Ok((mut tx, mut rx, client)) => {
                         let messages = inside_messages.clone();
                         let mut client = Some(client);
                         tasks_pool.spawn(Box::new(move || {
@@ -371,6 +375,8 @@ impl Server {
                                         messages.push(rq.into());
                                     }
                                 }
+                                rx.force_close_read();
+                                tx.force_close_write();
                             }
                         }));
                     }

--- a/src/util/refined_tcp_stream.rs
+++ b/src/util/refined_tcp_stream.rs
@@ -118,6 +118,7 @@ impl Write for Stream {
     }
 }
 
+#[derive(Clone)]
 pub struct RefinedTcpStream {
     stream: Stream,
     close_read: bool,
@@ -156,6 +157,14 @@ impl RefinedTcpStream {
 
     pub(crate) fn peer_addr(&mut self) -> IoResult<Option<SocketAddr>> {
         self.stream.peer_addr()
+    }
+
+    pub fn force_close_read(&mut self) {
+        let _ = self.stream.shutdown(Shutdown::Read);
+    }
+
+    pub fn force_close_write(&mut self) {
+        let _ = self.stream.shutdown(Shutdown::Write);
     }
 }
 


### PR DESCRIPTION
This is a small fix. Basically, upon taking the writer with `req.into_writer()`, dropping the writer doesn't always result in the connection being closed in client side, even when all content is flushed out.

This exposes two close functions to `tiny_http` internals, so that the client can be closed once all it's requests are received and processed fully.