### PR TITLE
Avoid panic if remote_addr has hung up

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -144,13 +144,18 @@ impl ClientConnection {
         std::mem::swap(&mut self.next_header_source, &mut data_source);
 
         // building the next reader
+        let remote_addr = match self.remote_addr.as_ref() {
+            Ok(addr) => *addr,
+            Err(e) => return Err(ReadError::ReadIoError(IoError::from(e.kind()))),
+        };
+
         let request = crate::request::new_request(
             self.secure,
             method,
             path,
             version.clone(),
             headers,
-            *self.remote_addr.as_ref().unwrap(),
+            remote_addr,
             data_source,
             writer,
         )


### PR DESCRIPTION
This was rarely crashing due to:
called `Result::unwrap()` on an `Err` value: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" }

tiny_http::client::ClientConnection::read (client.rs:153)
tiny_http::client::ClientConnection::next (client.rs:187)
tiny_http::Server::from_listener::{{closure}}::{{closure}} (lib.rs:333)